### PR TITLE
fix(docs): deploy vitepress build/1 so gh-pages dev/ resolves

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -60,7 +60,7 @@ makedocs(;
 
 deploydocs(;
     repo        = "github.com/epiforecasts/BVDOutbreakSize",
-    target      = "build",
+    target      = joinpath("build", "1"),
     branch      = "gh-pages",
     devbranch   = "main",
     push_preview = true,


### PR DESCRIPTION
## Root cause

The GitHub Pages site for `epiforecasts/BVDOutbreakSize` 404s at the bare docs URL.

DocumenterVitepress renders its site into a version-numbered subdirectory (`build/1/`).
With `deploydocs(target = "build")`, the whole `build/` tree (including the `1/` level) was pushed to `gh-pages`, so the site landed under `dev/1/` instead of `dev/`.

Result:
- `https://epiforecasts.io/BVDOutbreakSize/` -> 200 (root meta-refresh to `./dev/`)
- `https://epiforecasts.io/BVDOutbreakSize/dev/` -> 404 (no `dev/index.html`)
- `https://epiforecasts.io/BVDOutbreakSize/dev/1/` -> 200 (the real site, wrong path)

Pages config is correct (`gh-pages` branch, `/` root, enabled).

## Fix

Point `deploydocs(target = ...)` at the versioned build output `build/1` so the site contents land directly under `dev/`. On the next `Documenter` workflow run on `main`, `dev/index.html` will exist and the bare URL will resolve.

## Test plan

- [ ] Merge, let the `Documenter` workflow run on `main`
- [ ] Confirm `https://epiforecasts.io/BVDOutbreakSize/dev/` returns 200
- [ ] Confirm `https://epiforecasts.io/BVDOutbreakSize/` redirects to a working `dev/`

This was opened by a bot. Please ping @seabbs for any questions.