### PR TITLE
docs: name authors and add still-expected vs total deaths panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ extension, a no-onward-transmission projected-deaths counterfactual, a
 one-week-ahead forecast and an onset-to-death delay sensitivity
 analysis are added.
 
-**Authors:** Sam Abbott and contributors.
+**Authors:** Sam Abbott, Sam Brand and Sebastian Funk.
 The model code and analysis were drafted by a language model and
 reviewed and revised under human oversight; the named authors are
 responsible for that oversight.
@@ -93,9 +93,10 @@ the repository root (`output/posterior_summary.csv`,
 If you use or build on this project, please cite the three works
 this repository depends on:
 
-- **This project** — Abbott, S. (2026). *BVDOutbreakSize: joint
-  forward-generative Turing model for the 2026 DRC Bundibugyo
-  outbreak.* <https://github.com/epiforecasts/BVDOutbreakSize>.
+- **This project** — Abbott, S., Brand, S., Funk, S. (2026).
+  *BVDOutbreakSize: joint forward-generative Turing model for the
+  2026 DRC Bundibugyo outbreak.*
+  <https://github.com/epiforecasts/BVDOutbreakSize>.
 - **Imperial / WHO report** that this work re-implements —
   McCabe, R., Ebbarnezh, L., Okware, S., Fotsing, R., Koua, E.,
   Mbaka, P., Lofungola, A., van Elsland, S. L., McMenamin, M.,

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -16,10 +16,10 @@
 # one-week-ahead forecast and an onset-to-death delay sensitivity
 # analysis are added.
 #
-# **Authors.** Sam Abbott and contributors. The model code and this
-# analysis were drafted by a language model and reviewed and
-# revised under human oversight; the named authors are responsible
-# for that oversight (see the *LLM-driven reimplementation* limitation
+# **Authors.** Sam Abbott, Sam Brand and Sebastian Funk. The model
+# code and this analysis were drafted by a language model and
+# reviewed and revised under human oversight; the named authors are
+# responsible for that oversight (see the *LLM-driven reimplementation* limitation
 # below). The full analysis code lives in the
 # [epiforecasts/BVDOutbreakSize](https://github.com/epiforecasts/BVDOutbreakSize)
 # repository, where issues and suggestions are welcome.
@@ -1243,12 +1243,13 @@ joint_density_fig #hide
 
 # The cumulative case count `C(T) = exp(r T)` is set jointly by the
 # doubling time `τ` (equivalently the growth rate `r = log 2 / τ`) and
-# the time since seeding `T`. A reader who holds prior information on
-# the growth rate or on the outbreak's origin date can read off the
-# corresponding region of the joint `(τ, T)` posterior below and so
-# locate the implied outbreak size. The two are positively correlated:
-# a slower growth (larger `τ`) needs a longer elapsed `T` to reach the
-# same observed counts.
+# the time since seeding `T`. As a calendar date, `T` places the start
+# of sustained transmission at the data cut-off minus `T` days, so a
+# reader who holds prior information on the growth rate or on the
+# outbreak's origin date can read off the corresponding region of the
+# joint `(τ, T)` posterior below and locate the implied outbreak size.
+# The two are positively correlated: a slower growth (larger `τ`) needs
+# a longer elapsed `T` to reach the same observed counts.
 
 #md # ```@raw html
 #md # <details><summary>Joint (τ, T) posterior pair plot</summary>
@@ -1296,8 +1297,10 @@ no_onward_table = streams_table(
 
 no_onward_table #hide
 
-# Density of the projected total, with the observed death count marked
-# as a dashed black rule.
+# Two panels: the *still expected* deaths `ΔD` (future deaths in cases
+# already infected by `T`, net of those already observed) on the left,
+# and the *projected total* `D(T) + ΔD` on the right with the observed
+# death count marked as a dashed black rule.
 
 #md # ```@raw html
 #md # <details><summary>No-onward projected-deaths plot</summary>
@@ -1695,4 +1698,4 @@ CSV.write(joinpath(output_dir, "posterior_draws.csv"), posterior_draws)
 # The full analysis code, data and model definitions are in the
 # [epiforecasts/BVDOutbreakSize](https://github.com/epiforecasts/BVDOutbreakSize)
 # repository. Issues, corrections and suggestions are welcome there.
-# Maintained by Sam Abbott and contributors.
+# Maintained by Sam Abbott, Sam Brand and Sebastian Funk.

--- a/src/BVDOutbreakSize.jl
+++ b/src/BVDOutbreakSize.jl
@@ -19,7 +19,7 @@ import FastGaussQuadrature
 import CairoMakie
 import AlgebraOfGraphics as AoG
 import PairPlots
-using CairoMakie: Figure, Axis, hist!, vlines!
+using CairoMakie: Figure, Axis, hist!, density!, vlines!
 
 export REPORT_SCENARIOS,
        ITURI_POPULATION, ITURI_DAILY_TRAVEL,
@@ -657,26 +657,34 @@ end
 """
     plot_no_onward_deaths(df; obs_deaths)
 
-AlgebraOfGraphics density of the projected-total distribution from
-[`predict_no_onward_deaths`](@ref) with a Makie vertical rule at
-`obs_deaths`. The vertical rule marks deaths already observed at
-time `T`; the density to its right is the lower-bound projection
-under the no-onward-transmission counterfactual.
+Two-panel density of the no-onward-transmission counterfactual from
+[`predict_no_onward_deaths`](@ref). The left panel shows the *still
+expected* deaths (`:delta_deaths`, the future deaths in cases already
+infected by `T`, net of the `obs_deaths` already observed). The right
+panel shows the *projected total* (`:total_projected = obs_deaths +
+delta_deaths`) with a dashed black rule at `obs_deaths`. Both are
+lower bounds: they assume every onward transmission stops at time `T`.
 """
 function plot_no_onward_deaths(df::DataFrame; obs_deaths::Real)
-    spec = AoG.data(df) *
-           AoG.mapping(:total_projected =>
-                       "Projected total deaths (no onward transmission)") *
-           AoG.AlgebraOfGraphics.density() *
-           AoG.visual(linewidth = 2, color = :firebrick)
-    fg = AoG.draw(spec;
-        axis = (; ylabel = "Posterior density",
-                  title  = "Lower bound under no onward transmission"),
-        figure = (; size = (760, 420)),
-    )
-    vlines!(fg.figure.content[1], [float(obs_deaths)];
+    fig = Figure(; size = (980, 420))
+
+    ax1 = Axis(fig[1, 1];
+        xlabel = "Still expected deaths (beyond those already observed)",
+        ylabel = "Posterior density",
+        title  = "Still expected (future)")
+    density!(ax1, df.delta_deaths; color = (:firebrick, 0.5),
+             strokecolor = :firebrick, strokewidth = 2)
+
+    ax2 = Axis(fig[1, 2];
+        xlabel = "Projected total deaths (no onward transmission)",
+        ylabel = "Posterior density",
+        title  = "Projected total")
+    density!(ax2, df.total_projected; color = (:firebrick, 0.5),
+             strokecolor = :firebrick, strokewidth = 2)
+    vlines!(ax2, [float(obs_deaths)];
             color = :black, linestyle = :dash, linewidth = 2)
-    return fg
+
+    return fig
 end
 
 ## --- One-week-ahead forecast --------------------------------------------

--- a/test/test_no_onward_deaths.jl
+++ b/test/test_no_onward_deaths.jl
@@ -39,5 +39,5 @@ end
     df = predict_no_onward_deaths(chn; obs_deaths = 50)
     fg = plot_no_onward_deaths(df; obs_deaths = 50)
     @test fg !== nothing
-    @test fg.figure isa CairoMakie.Makie.Figure
+    @test fg isa CairoMakie.Makie.Figure
 end


### PR DESCRIPTION
Follow-up to #23, addressing Seb's review issues that were not yet covered.

## Changes
- **#13 (authors):** name Sam Abbott, Sam Brand and Sebastian Funk as the
  human authors responsible for oversight — in the README, the analysis
  page, the citation entry and the maintainer line.
- **#21 (sbfnk follow-up):** the no-onward-transmission counterfactual now
  plots the *still expected* deaths (future deaths in cases already
  infected by `T`, net of those already observed) alongside the *projected
  total* in a two-panel figure, rather than only the total with the
  observed count marked. Test contract updated for the new `Figure` return.
- **#14:** state the implied seeding date as the data cut-off minus `T`
  days in the `(τ, T)` section so the elapsed time reads as a calendar
  date. Kept prose-only to avoid adding a `Dates` dependency to both build
  environments.

## Test plan
- [ ] CI: Tests green
- [ ] CI: Documenter build green (executes the literate, exercising the
      two-panel plot)

This was opened by a bot. Please ping @seabbs for any questions.