### PR TITLE
docs: clarify model scope in README and limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ reimplementation of the
 report's approach and its original published estimates.
 <!-- ABSTRACT:END -->
 
+**Scope.** This model is a re-analysis of the McCabe et al. Imperial College report and is not a general-purpose outbreak-size estimator. The priors, likelihood structure, data streams, and epidemiological framing are anchored to that specific work. Users applying this to other outbreaks or data snapshots should reassess whether the framing carries over; the model may be developed beyond this use-case in future.
+
 **Use of AI:** The model code and analysis were drafted by a language
 model and reviewed and revised under human oversight; the named authors
 are responsible for that oversight.

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -95,6 +95,12 @@
 #
 # ## Limitations
 #
+# - *Scope anchored to the McCabe et al. report.* This model is a re-analysis of the
+#   McCabe et al. [mccabe2026](@cite) Imperial College report, not a standalone
+#   outbreak-size estimator. The priors, likelihood structure, data streams, and
+#   epidemiological assumptions are chosen in response to that specific work.
+#   Users applying this to other outbreaks or data snapshots should reassess whether
+#   the framing carries over; the model may be developed beyond this use-case in future.
 # - *Fitted only to aggregate reported counts.* The data are a
 #   handful of summary figures — total suspected cases in the DRC,
 #   total suspected deaths in the DRC, and cases (and one death)


### PR DESCRIPTION
## Summary

- Adds explicit **Scope** paragraph to README (after abstract) stating this is a McCabe et al. re-analysis, not a general-purpose estimator
- Adds scope as the **first** Limitations bullet in `analysis.jl`, so it frames all other limitations

[created via claude, reviewed by @kathsherratt]

Closes #64