### PR TITLE
plot_forecast: relabel y axis "Predictive frequency"

### DIFF
--- a/src/BVDOutbreakSize.jl
+++ b/src/BVDOutbreakSize.jl
@@ -1024,7 +1024,7 @@ function plot_forecast(fc::DataFrame)
         v = fc[!, col]
         upper = max(1.0, quantile(v, 0.995))
         ax = Axis(fig[1, i];
-            xlabel = title, ylabel = "Forecast count",
+            xlabel = title, ylabel = "Predictive frequency",
             title = "One week ahead", limits = ((0, upper), nothing))
         hist!(ax, v; bins = range(0, upper; length = 30),
               color = (colour, 0.7))


### PR DESCRIPTION
This PR closes #56.

`plot_forecast()` shows histograms of draws from the posterior predictive, so the y-axis label "Forecast count" is misleading. Renamed to "Predictive frequency".