### PR TITLE
docs: cite WHO sitreps as source of outbreak counts in the Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,14 +178,24 @@ where past and development versions of the analysis page can be found.
 
 ## Citation
 
-If you use or build on this project, please cite the three works
-this repository depends on:
+If you use or build on this project, please cite the works this
+repository depends on:
 
 - **This project** — Abbott, S., Brand, S., Funk, S. (2026).
   *BVDOutbreakSize: joint forward-generative Turing model for the
   2026 DRC Bundibugyo outbreak.*
   <https://github.com/epiforecasts/BVDOutbreakSize>.
   DOI: [10.5281/zenodo.20312758](https://doi.org/10.5281/zenodo.20312758).
+- **WHO situation reports** that supply the DRC suspected-case and
+  suspected-death counts and the Uganda export-case counts —
+  World Health Organization Regional Office for Africa (2026).
+  *Ebola disease caused by Bundibugyo virus outbreak, Democratic
+  Republic of the Congo and Uganda — Weekly External Situation
+  Report 01.* Data as of 18 May 2026.
+  World Health Organization (2026). *Disease Outbreak News:
+  Ebola disease caused by Bundibugyo virus — Uganda (DON602).*
+  Source of the first Uganda export hospital-admission date
+  (11 May 2026) and the fatal export death date (14 May 2026).
 - **Imperial reports** that this work re-implements and compares
   against, in both released versions —
   McCabe, R., Ebbarnezh, L., Okware, S., Fotsing, R., Koua, E.,

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -250,17 +250,20 @@ Random.seed!(20260518)
 #
 # ### Data
 #
-# The analysis uses a handful of aggregate counts collated from
-# situation reports and news coverage: the suspected cases and
-# suspected deaths reported in the DRC, the cases (and any deaths)
-# detected among travellers to Uganda, and the daily cross-border
-# traveller volume and source-area population from the McCabe et al.
-# report [mccabe2026](@cite). All are point-in-time totals as of the
-# data cut-off, not time series, and the suspected counts are
-# unconfirmed. The table below lists each figure with its source. The
-# source population is treated as fixed (census data); the daily
-# outbound traveller volume is given a normal prior centred at the
-# McCabe et al. figure with an SD covering point-of-entry variation.
+# The analysis uses a handful of aggregate counts. The DRC suspected
+# cases and suspected deaths and the Uganda export-case counts and
+# deaths come from WHO AFRO Weekly External Situation Report 01, data
+# as of 18 May 2026 [who_afro_sitrep01_2026](@cite); the first-export
+# hospital-admission date and the dated death among the exports come
+# from WHO Disease Outbreak News DON602 [who_don_2026_602](@cite).
+# The daily cross-border traveller volume and source-area population
+# are taken from the McCabe et al. report [mccabe2026](@cite). All are
+# point-in-time totals as of the data cut-off, not time series, and
+# the suspected counts are unconfirmed. The table below lists each
+# figure with its source. The source population is treated as fixed
+# (census data); the daily outbound traveller volume is given a normal
+# prior centred at the McCabe et al. figure with an SD covering point-
+# of-entry variation.
 
 #md # ```@raw html
 #md # <details><summary>Loading observations and building the data table</summary>

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -15,6 +15,30 @@
   doi     = {10.1371/journal.pcbi.1012520},
 }
 
+@misc{who_afro_sitrep01_2026,
+  author       = {{World Health Organization Regional Office for Africa}},
+  title        = {Ebola disease caused by {Bundibugyo} virus outbreak,
+                  {Democratic Republic of the Congo} and {Uganda} —
+                  Weekly External Situation Report 01},
+  year         = {2026},
+  month        = {May},
+  note         = {Data as of 18 May 2026. Primary source of the DRC
+                  suspected-case and suspected-death counts and the
+                  Uganda export-case counts used in this analysis.},
+}
+
+@misc{who_don_2026_602,
+  author       = {{World Health Organization}},
+  title        = {Disease Outbreak News: {Ebola} disease caused by
+                  {Bundibugyo} virus — {Uganda} (DON602)},
+  year         = {2026},
+  month        = {May},
+  note         = {Source of the first Uganda export hospital-admission
+                  date (11 May 2026) and the dated export death
+                  (14 May 2026) used as timing bounds on the seeding
+                  time $T$ in this analysis.},
+}
+
 @misc{mccabe2026,
   title       = {Estimation of the size of the outbreak of Ebola
                  disease caused by Bundibugyo virus in the Democratic


### PR DESCRIPTION
## Summary

The Data section of the analysis page attributed the input counts to "situation reports and news coverage" and only cited the McCabe et al. report, even though the outbreak counts themselves actually come from the WHO sitreps (per `data/observations.toml`):

- DRC suspected cases / suspected deaths and Uganda export-case counts → **WHO AFRO Weekly External Situation Report 01** (data as of 18 May 2026)
- First export hospital-admission date and the dated export death → **WHO Disease Outbreak News DON602**
- Daily cross-border traveller volume and source-area population → **McCabe et al.** (unchanged)

This PR:

- Adds bib entries `who_afro_sitrep01_2026` and `who_don_2026_602` to `docs/src/refs.bib`.
- Rewrites the Data section in `docs/examples/analysis.jl` to attribute each count to its actual source and cite the two WHO documents alongside the McCabe et al. cite for the traveller / population inputs.
- Adds the WHO sitreps to the README citation block, next to the Imperial reports.

## Test plan

- [ ] Docs build (`julia --project=docs docs/make.jl`) resolves the new `who_afro_sitrep01_2026` and `who_don_2026_602` citations without warnings.
- [ ] Rendered Data section shows the WHO sitrep / DON cites and the bibliography page lists both new entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BMgWSriDfMCiNAXnt5oAyS)_