### PR TITLE
fix: guard forecast export integral against r ≈ 0

### DIFF
--- a/src/BVDOutbreakSize.jl
+++ b/src/BVDOutbreakSize.jl
@@ -1301,7 +1301,14 @@ function forecast_reported(chn;
         ## Uganda exports: p_uganda · q · ∫_{T+h−w}^{T+h} C(s) ds (closed
         ## form for exponential growth).
         lo = max(Th - w[i], zero(Th))
-        μ_exports = pu[i] * q * (exp(r[i] * Th) - exp(r[i] * lo)) / r[i]
+        # When r ≈ 0 the closed-form ∫ exp(r·s) ds degenerates; use the
+        # l'Hôpital limit (Th − lo) to avoid NaN from 0/0.
+        ri = r[i]
+        μ_exports = if abs(ri) < eps(typeof(ri))
+            pu[i] * q * (Th - lo)
+        else
+            pu[i] * q * (exp(ri * Th) - exp(ri * lo)) / ri
+        end
         exports_cum[i] = rand(rng, Poisson(max(μ_exports, eps(μ_exports))))
     end
 


### PR DESCRIPTION
## Summary

The closed-form integral `(exp(r·Th) − exp(r·lo)) / r` in `forecast_reported` (line 1304) produces `NaN` when the growth rate `r` is exactly or nearly zero.

This PR adds a guard that uses the l'Hôpital limit `(Th − lo)` as a fallback when `|r| < eps`.

## Motivation

Discovered via formal verification of the package's mathematical claims in Lean 4. The Lean proof (`exponential_export_integral_closed`) requires an explicit `r ≠ 0` hypothesis. The current exponential-growth model always yields `r > 0`, but this guard makes `forecast_reported` robust to alternative growth priors that may allow `r = 0`.

## Changes

- `src/BVDOutbreakSize.jl`: Add `abs(ri) < eps` branch with the zero-growth limit formula.