### PR TITLE
Restore isolation panel in the vintage conditional PPC plot

### DIFF
--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -2682,9 +2682,9 @@ pp_joint = predict(
 ## `replicates` shape `plot_vintage_conditional_ppc` grounds on each
 ## vintage's observed previous cumulative for the one-step-ahead
 ## predictive. Find it by its prefix among the predict keys.
-function _vintage_replicates(pp, prefix)
+function _vintage_replicates(pp, prefix, suffix = "increments")
     key = first(k for k in keys(pp)
-    if occursin("$prefix.increments", string(k)))
+    if occursin("$prefix.$suffix", string(k)))
     return collect(pp[key])
 end;
 
@@ -2713,8 +2713,16 @@ suspected_daily_panel = (;
 ## with `cumulative = false` — each replicate is the modelled bed count on a
 ## report day against the observed "Patients en isolement" count. The count
 ## is the suspect inflow carried through a length-of-stay survival, so its
-## level and lag reflect the admission proportion and the stays.
-
+## level and lag reflect the admission proportion and the stays. The censored-
+## occupancy likelihood stores its per-day predictive draws under the submodel
+## `obs` variable (not `increments`), so the replicates are read from that key.
+isolation_panel = (;
+    title = "Patients in isolation",
+    dates = _vintage_dates(obs.isolation_history.days),
+    replicates = _vintage_replicates(
+        pp_joint, "treatment_state.isolation", "obs"),
+    observed = obs.isolation_history.counts,
+    colour = :darkorange, cumulative = false);
 deaths_panel = (;
     title = "Suspected deaths",
     dates = _vintage_dates(obs.deaths_history.days),
@@ -2819,7 +2827,7 @@ recovered_panel = (;
 ## confirmed panels show the full series the model is fitting, not just the
 ## window the suspected streams cover.
 joint_vintage_ppc_fig = plot_vintage_conditional_ppc(
-    [reported_panel, suspected_daily_panel, confirmed_panel,
+    [reported_panel, suspected_daily_panel, isolation_panel, confirmed_panel,
     deaths_panel, suspected_daily_deaths_panel, confirmed_deaths_panel,
     recovered_panel, tests_analysed_panel, tests_analysed_daily_panel]);
 

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -1360,7 +1360,7 @@ cfr_prior_fig #hide
 #md # Markdown.parse(string("```julia\n",
 #md #     (@code_string BVDOutbreakSize.treatment_admission_model(
 #md #         (; days = Int[], counts = Int[]),
-#md #         Float64[], Float64[], 0.25, [1.0])), "\n```"))
+#md #         Float64[], Float64[], 0.25)), "\n```"))
 #md # ```
 
 #md # ```@raw html

--- a/scripts/validate_ppc.jl
+++ b/scripts/validate_ppc.jl
@@ -19,6 +19,7 @@ pp_joint = predict(
         confirmed_deaths = missing,
         deaths_history = _days_only(obs.deaths_history),
         reported_history = _days_only(obs.reported_history),
+        isolation_history = _days_only(obs.isolation_history),
         confirmed_history = obs.confirmed_history,
         confirmed_deaths_history = obs.confirmed_deaths_history,
         lab_history = obs.lab_history,
@@ -30,9 +31,9 @@ pp_joint = predict(
     chn)
 println("predict OK; ", length(keys(pp_joint)), " predicted variables")
 
-function _vintage_replicates(pp, prefix)
+function _vintage_replicates(pp, prefix, suffix = "increments")
     key = first(k for k in keys(pp)
-    if occursin("$prefix.increments", string(k)))
+    if occursin("$prefix.$suffix", string(k)))
     return collect(pp[key])
 end
 _vintage_dates(days) = string.(obs.seeding .+ Day.(days .- 1))
@@ -41,6 +42,15 @@ reported_panel = (; title = "Suspected cases",
     dates = _vintage_dates(obs.reported_history.days),
     replicates = _vintage_replicates(pp_joint, "cases_state.reported_increments"),
     observed = obs.reported_history.counts, colour = :steelblue)
+# Isolation occupancy is a daily (non-cumulative) count fitted by the
+# censored-occupancy likelihood, whose per-day predictive draws are stored
+# under the submodel `obs` variable rather than `increments`.
+isolation_panel = (; title = "Patients in isolation",
+    dates = _vintage_dates(obs.isolation_history.days),
+    replicates = _vintage_replicates(
+        pp_joint, "treatment_state.isolation", "obs"),
+    observed = obs.isolation_history.counts,
+    colour = :darkorange, cumulative = false)
 deaths_panel = (; title = "Suspected deaths",
     dates = _vintage_dates(obs.deaths_history.days),
     replicates = _vintage_replicates(pp_joint, "deaths_state.death_increments"),
@@ -52,7 +62,7 @@ tests_analysed_panel = (; title = "Specimens analysed",
     observed = obs.lab_history.counts, colour = :seagreen)
 
 fig = plot_vintage_conditional_ppc(
-    [reported_panel, deaths_panel, tests_analysed_panel])
+    [reported_panel, isolation_panel, deaths_panel, tests_analysed_panel])
 println("panel figure built OK: ", typeof(fig))
 import CairoMakie
 CairoMakie.save("logs/validate_ppc.png", fig)


### PR DESCRIPTION
## Summary

Restores the **"Patients in isolation"** panel to the joint vintage conditional posterior-predictive figure in `docs/examples/analysis.jl`. It was dropped in #289 ("Fix isolation") because the lookup had broken.

## Why it had broken

The isolation/treatment-bed stream now defaults to the **censored-occupancy likelihood** (`saturation = :censored`, `censored_occupancy_model`), which stores its per-day predictive draws under the submodel `obs` variable — i.e. the predict key `treatment_state.isolation.obs`. The panel helper `_vintage_replicates` only ever searched for `.increments`, so the lookup failed and the panel was removed rather than fixed.

## Changes

- Generalise `_vintage_replicates` to accept the variable suffix (defaults to `increments`, so every existing call is unchanged).
- Re-add `isolation_panel`, reading replicates from `treatment_state.isolation.obs`, and put it back into the `plot_vintage_conditional_ppc` call. It stays a non-cumulative (daily-count) panel, matching the occupancy semantics.
- Extend `scripts/validate_ppc.jl` to pass `isolation_history` and exercise the restored panel against the saved chain, so the predict-key path is de-riskable without re-fitting.

## Validation

The panel is exercised when the docs build runs the analysis literate (fitting the chains). For a quick local check against a saved reduced chain (`logs/joint_chain.jls`), run:

```
julia --project=. scripts/validate_ppc.jl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHAmKzbLQvzqEfXcTSYXkg)_