### PR TITLE
Start the Rt random walk two weeks before the first situation report

### DIFF
--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -2453,15 +2453,17 @@ infection_delay_pair_fig #hide
 #md # <details><summary>Reproduction-number trajectory</summary>
 #md # ```
 
+## `rt_start` is the renewal/established-window start the plot shows from;
+## `rt_walk_start` is where the random walk's knots begin — `RT_WALK_LEAD`
+## days (two weeks) before the first situation report, matching `bvd_joint`'s
+## `rt_walk_lead` — so the chain reconstruction uses the same knot grid the
+## model did, floored at the renewal start. R_t is flat at R0 between the two.
+_rt_start_plot = clamp(
+    obs.n - round(Int, obs.tmrca_days) + RENEWAL_START_LEAD, 1, obs.n);
 rt_fig = plot_rt(chn_joint;
     n = obs.n, breakpoint = _BREAKPOINT,
-    ## `rt_start` is the renewal/established-window start the plot shows from;
-    ## `rt_walk_start` is where the random walk's knots begin (the first
-    ## situation report), so the chain reconstruction uses the same knot grid
-    ## the model did. R_t is flat at R0 between the two.
-    rt_start = clamp(
-        obs.n - round(Int, obs.tmrca_days) + RENEWAL_START_LEAD, 1, obs.n),
-    rt_walk_start = _BREAKPOINT,
+    rt_start = _rt_start_plot,
+    rt_walk_start = clamp(_BREAKPOINT - RT_WALK_LEAD, _rt_start_plot, obs.n),
     as_of_date = string(obs.cutoff), seeding = obs.seeding,
     ramp = 21.0);
 

--- a/docs/src/news.md
+++ b/docs/src/news.md
@@ -12,6 +12,13 @@ Changes since v1.5.0.
 
 ### Model
 
+- The reproduction-number random walk now starts two weeks BEFORE the first
+  situation report (the new `RT_WALK_LEAD = 14` lead, exposed as the
+  `bvd_joint` keyword `rt_walk_lead`) rather than exactly at it, so `R_t` is
+  free to move over the fortnight of transmission leading up to the first
+  report instead of being held flat at `R0` right to it. The walk start is
+  floored at the renewal start so it never precedes the seeded trajectory, and
+  the `plot_rt` reconstruction uses the same earlier knot grid.
 - Added a supply-limited isolation/treatment-bed stream ("Patients en
   isolement"), the renewal analogue of the convolution secondary-observation
   model of EpiNow2.

--- a/scripts/validate_full.jl
+++ b/scripts/validate_full.jl
@@ -98,7 +98,7 @@ println("5-panel vintage PPC built OK (incl. confirmed-case late windows + ",
 ## Rt plot + forecast (the other new pieces).
 rtf = plot_rt(chn; n = obs.n, breakpoint = BP,
     rt_start = clamp(obs.n - round(Int, obs.tmrca_days), 1, obs.n),
-    rt_walk_start = BP,
+    rt_walk_start = clamp(BP - RT_WALK_LEAD, 1, obs.n),
     as_of_date = string(obs.cutoff), seeding = obs.seeding)
 println("plot_rt OK")
 fc = forecast_reported(chn; horizon = 7)

--- a/scripts/validate_report.jl
+++ b/scripts/validate_report.jl
@@ -115,7 +115,7 @@ println("OK scalar PP (exports + confirmed deaths): ", "ok")
 
 # --- Rt trajectory (established window) ---
 fig3 = plot_rt(chn; n = obs.n, breakpoint = _BREAKPOINT,
-    rt_walk_start = _BREAKPOINT,
+    rt_walk_start = clamp(_BREAKPOINT - RT_WALK_LEAD, 1, obs.n),
     as_of_date = string(obs.cutoff), seeding = obs.seeding)
 CairoMakie.save("logs/val_rt.png", fig3)
 println("OK Rt trajectory: ", "ok")

--- a/src/BVDOutbreakSize.jl
+++ b/src/BVDOutbreakSize.jl
@@ -28,7 +28,7 @@ using CairoMakie: Figure, Axis, hist!, density!, vlines!, hlines!, vspan!,
 
 export REPORT_SCENARIOS, REPORT_SCENARIOS_CI,
        ITURI_POPULATION, ITURI_DAILY_TRAVEL,
-       ITURI_DAILY_TRAVEL_SD, RENEWAL_START_LEAD,
+       ITURI_DAILY_TRAVEL_SD, RENEWAL_START_LEAD, RT_WALK_LEAD,
        load_observations, freeze_observations, m_prior_centre,
        summary_table, posterior_summary,
        fit_diagnostics, diagnostics_table,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -158,6 +158,19 @@ sustained transmission is treated as confidently established.
 const RENEWAL_START_LEAD = 14
 
 """
+    RT_WALK_LEAD
+
+Days BEFORE the first situation report (`breakpoint`) at which the
+reproduction-number random walk is allowed to start moving, rather than
+holding `R_t` flat at `R0` right up to the report. Two weeks lets the walk
+capture the transmission dynamics in the fortnight leading up to the first
+report — the response decline can begin before the outbreak is first
+reported — while staying floored at the renewal start so the walk never
+precedes the seeded trajectory.
+"""
+const RT_WALK_LEAD = 14
+
+"""
     ITURI_POPULATION
 
 Source population for the Ituri Province (McCabe et al., Table 1).

--- a/src/models/joint.jl
+++ b/src/models/joint.jl
@@ -405,7 +405,8 @@ death-confirmation positivity (`death_confirmation`).
         genetic = nothing,
         tmrca_days::Union{Missing, Real} = missing,
         tmrca_days_sd::Real = 15.0,
-        renewal_start_lead::Integer = RENEWAL_START_LEAD)
+        renewal_start_lead::Integer = RENEWAL_START_LEAD,
+        rt_walk_lead::Integer = RT_WALK_LEAD)
     ## The renewal start sits `renewal_start_lead` days AFTER the genetic
     ## TMRCA day (`n - tmrca_days + lead`), past the TMRCA's uncertainty where
     ## sustained transmission is confident. The lead keeps the observed span
@@ -415,15 +416,15 @@ death-confirmation positivity (`death_confirmation`).
     ## grows from here.
     rt_start = ismissing(tmrca_days) ? 1 :
                clamp(n - round(Int, tmrca_days) + renewal_start_lead, 1, n)
-    ## Hold R_t flat at R0 until the first situation report (`breakpoint`),
-    ## starting the random walk there rather than at the renewal start. Between
-    ## the renewal start and the first report there is no case or death
-    ## surveillance, so the outbreak follows the established `R0` and a free
-    ## walk over that window only adds drift the data cannot support; the
-    ## intervention ramp then layers the response decline on top from the
-    ## breakpoint. With no breakpoint the walk falls back to the renewal start.
+    ## Start the random walk `rt_walk_lead` days (two weeks by default) BEFORE
+    ## the first situation report (`breakpoint`) rather than exactly at it, so
+    ## R_t is free to move over the fortnight of transmission leading up to the
+    ## first report instead of being held flat at R0 right to it (the response
+    ## decline can begin before the outbreak is first reported). The start is
+    ## floored at the renewal start so the walk never precedes the seeded
+    ## trajectory. With no breakpoint the walk falls back to the renewal start.
     rt_walk_start = ismissing(breakpoint) ? rt_start :
-                    clamp(round(Int, breakpoint), 1, n)
+                    clamp(round(Int, breakpoint) - rt_walk_lead, rt_start, n)
     latent ~ to_submodel(
         _latent(n, breakpoint, infection, onset_incidence;
             rt_start, rt_walk_start), false)


### PR DESCRIPTION
## Summary

Moves the start of the reproduction-number random walk **two weeks earlier**.

Previously the `R_t` walk started exactly at the first situation report (`breakpoint`), holding `R_t` flat at `R0` right up to it. Now it starts `rt_walk_lead` days before:

```julia
rt_walk_start = ismissing(breakpoint) ? rt_start :
                clamp(round(Int, breakpoint) - rt_walk_lead, rt_start, n)
```

So `R_t` is free to move over the fortnight of transmission leading up to the first report, rather than being pinned at `R0` until the outbreak is first reported (the response decline can begin before reporting). The start is **floored at the renewal start** so the walk never precedes the seeded trajectory; with no breakpoint it still falls back to the renewal start.

## Changes

- New exported constant **`RT_WALK_LEAD = 14`** (`src/constants.jl`), and a `bvd_joint` keyword **`rt_walk_lead::Integer = RT_WALK_LEAD`** so the lead is explicit and tunable (mirroring the existing `renewal_start_lead`/`RENEWAL_START_LEAD` pattern).
- `bvd_joint` uses it to start the walk two weeks before the breakpoint.
- `plot_rt` reconstruction in `analysis.jl` and the two `validate_*` scripts use the same earlier knot grid, so the plotted walk matches the model.
- News entry under v1.6.0 → Model.

## Notes

- Only `bvd_joint` computes `rt_walk_start` from the breakpoint; the single-stream composers already default the walk start to the renewal start, so they're unchanged.
- No tests assume the old walk start (`test_exponential_growth` passes `rt_walk_start` to `infection_model` directly; nothing asserts `bvd_joint`'s walk start equals the breakpoint).
- This is a modelling change, so the substantive effect (a different posterior `R_t` trajectory in the lead-up to the first report) only shows in a refit — visible in the docs build's rendered analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHAmKzbLQvzqEfXcTSYXkg)_