### PR TITLE
Sensitivity experiment: does the isolation stream pin the joint outbreak size low?

### DIFF
--- a/notes/isolation-pinning.md
+++ b/notes/isolation-pinning.md
@@ -1,0 +1,135 @@
+# Why the isolation stream pins the joint outbreak size low
+
+## Observation
+
+In recent dev fits the joint posterior outbreak size `C_T` (cumulative
+infections at the cut-off) sits well below what most single-stream fits imply
+on their own. From the released analysis (per-stream `C_T`, 90% CrI):
+
+| stream          | 90% CrI of C_T |
+|-----------------|----------------|
+| exports         | 915 – 25 733   |
+| deaths (DRC)    | 4 866 – 19 289 |
+| cases (DRC)     | 5 867 – 17 429 |
+| confirmed (DRC) | 7 412 – 28 773 |
+| **isolation**   | **1 548 – 12 869** |
+| **joint**       | **1 723 – 4 112** |
+
+The deaths / cases / confirmed streams individually want a *large* outbreak
+(several thousand to tens of thousands). The **isolation** stream is the one
+single-stream fit whose lower bound anchors near the joint, and the joint
+ends up close to the bottom of that range. So when isolation is added to the
+mix it pulls `C_T` down hard — the user's "pinned low" observation.
+
+## Mechanism
+
+The isolation/treatment-bed stream (`treatment_admission_model` in
+`src/models/observations.jl`) fits the daily occupied-bed count
+("Patients en isolement") as a length-of-stay survival of the *admitted*
+suspect inflow:
+
+- BVD demand  = `convolve_survival(p_iso_bvd · p_drc · bvd_reports_daily, bvd_los.pmf)`
+- background  = `convolve_survival(p_iso · bg_daily, ruleout_los.pmf)`
+- occupancy   = `min(demand, usable_frac · C)` (censored saturation), observed
+  beds ~ NegBinomial(occupancy).
+
+By Little's law (stated in the `isolation_admission_model` docstring):
+
+```
+mean occupancy  ≈  p_iso · admissions · (E[LOS] + 1)
+```
+
+The occupied-bed count is *observed* (~376 beds at the cut-off). For a fixed
+observed occupancy, a **high admission fraction × long stay** means each
+occupied bed corresponds to *few* suspect admissions, hence a *small* implied
+suspect inflow and a *small* outbreak. So the isolation stream maps the bed
+count into `C_T` through the product `p_iso · E[LOS]`, and that product is the
+lever.
+
+## Hypothesis (what to test)
+
+The low pin is driven by the **admission fraction `p_iso` (`Beta(2,2)`, mean
+0.5) × BVD length-of-stay (~12 d) product** being effectively *high* and only
+*weakly identified*. `p_iso` and `E[LOS]` are explicitly confounded for the
+occupancy *level* (only their product is pinned by the level; the shape/lag of
+the daily curve adds weak extra information). So the implied outbreak size
+rides on the prior centres of these two quantities, not on the data, and those
+centres happen to sit high — squeezing `C_T` down.
+
+The released isolation posteriors are consistent with this:
+
+- `isolation_admission` (`p_iso`): 90% CrI **0.19 – 0.54**, median ~0.29 — the
+  data pulls it *down* from the prior mean of 0.5 but it stays substantial and
+  the interval is wide (weakly identified, as predicted).
+- `isolation BVD length-of-stay mean`: 90% CrI **5.4 – 19.3 d**, median ~12 d —
+  essentially the prior; the occupancy does not sharpen it much.
+- `isolation non-BVD rule-out stay mean`: 90% CrI **1.4 – 6.7 d**.
+- bed capacity ~ 410 – 462, expected occupancy ~ 371 – 434, bed shortfall
+  ~ 0 (censoring inactive at current utilisation).
+
+A high admission-rate × ~12 d stay is exactly the configuration that turns
+~376 beds into a small suspect count.
+
+## The experiment (`scripts/experiment_isolation_sensitivity.jl`)
+
+Two complementary tests, both reading posterior `C_T`:
+
+**(A) Joint leave-one-out.** Fit the full joint with isolation *included* vs
+*excluded* (excluded by passing an empty `isolation_history`, so the treatment
+submodel samples from its prior and contributes no likelihood). If isolation
+pins `C_T` low, removing it should **raise** the joint `C_T` toward what the
+other streams want. This is the direct demonstration of the pull.
+
+**(B) Isolation single-stream assumption variants.** Refit the isolation
+single-stream (`treatment_only_model`) under:
+
+- *baseline* — shipped priors (`p_iso ~ Beta(2,2)`, BVD LOS ~12 d);
+- *low admission* — inject `admission = isolation_admission_model(p_prior = Beta(2,6))`
+  (mean 0.25 instead of 0.5);
+- *short BVD LOS* — re-centre the BVD stay on ~6 d instead of ~12 d.
+
+Both alternatives *reduce* the `p_iso · E[LOS]` product, so each should
+**raise** the single-stream `C_T`. Whichever variant moves `C_T` most is the
+assumption that most pins it low. The hypothesis predicts both move it up, and
+quantifies their relative weight (admission fraction vs length-of-stay).
+
+The script prints a comparison table of `C_T` medians / 90% / 60% intervals
+across all five settings and saves a density overlay to
+`logs/isolation_sensitivity_C_T.png`.
+
+### How to read the output
+
+- **(A):** "joint, isolation EXCLUDED" median **higher** than "...INCLUDED"
+  confirms isolation pins the joint low; the printed delta quantifies the pull
+  in infections.
+- **(B):** if *low admission* and/or *short BVD LOS* raise the single-stream
+  `C_T` substantially, that assumption is a driver. Compare the two deltas to
+  rank admission fraction vs length-of-stay. If the single-stream baseline
+  `C_T` is already low and the variants lift it toward the deaths/cases level,
+  the prior centres — not the bed data — were holding it down.
+
+## Judgement on reasonableness
+
+The mechanism is structurally sound: occupancy genuinely *is* admissions ×
+stay, and that is the correct way to read a prevalence (stock) stream into an
+incidence (flow) quantity. The concern is **identifiability, not the model
+form**. Because only the *product* `p_iso · E[LOS]` is pinned by the occupancy
+level, the implied outbreak size is effectively *set by the priors* on those
+two quantities — and `Beta(2,2)` (mean 0.5 admission) combined with a ~12 d
+BVD stay is a fairly aggressive, high-retention assumption. If the true
+admission fraction is lower (many suspects are never bedded) or the effective
+BVD stay shorter (faster turnover/transfer/death), the bed count implies a
+*larger* outbreak, and the joint should not be dragged so far below the
+deaths/cases/confirmed consensus.
+
+So the pin is **plausible but fragile**: it is reasonable *if* you believe
+roughly half of ascertained suspects occupy a bed for ~12 days, and
+*unreasonable to lean on* otherwise, because the data barely constrains that
+product. The recommendation is to (i) confirm the size of the pull via test
+(A), (ii) check whether a more defensible, lower admission prior (e.g.
+`Beta(2,6)`) materially relaxes it via test (B), and (iii) if so, consider a
+tighter, better-justified prior on `p_iso` or `E[LOS]` (or down-weighting the
+isolation stream's influence on `C_T`) rather than letting a weakly-identified
+product anchor the headline outbreak size.
+
+This note and the script are a *diagnostic*; they do not modify the model.

--- a/scripts/experiment_isolation_sensitivity.jl
+++ b/scripts/experiment_isolation_sensitivity.jl
@@ -1,0 +1,201 @@
+# Sensitivity experiment: does the isolation/treatment-bed stream pin the
+# joint cumulative-infection estimate (C_T) low, and which single isolation
+# assumption drives it?
+#
+# Background (see notes/isolation-pinning.md). In recent dev fits the joint
+# C_T sits well below what the deaths / cases / confirmed streams imply on
+# their own (per-stream table in the released analysis: isolation ~90% CI
+# 1548-12869 with its lower bound anchoring the joint 1723-4112, while
+# deaths/cases/confirmed all sit at 4800-28000). The isolation occupancy is
+# fitted as a length-of-stay survival of the admitted suspect inflow:
+#   bed demand ~= p_iso * admissions * (E[LOS] + 1)   (Little's law)
+# so a HIGH admission fraction (p_iso ~ Beta(2,2), mean 0.5) times a LONG BVD
+# stay (~12 d) makes a fixed observed bed count imply FEW suspects, hence a
+# small outbreak. p_iso and LOS are confounded for the occupancy LEVEL, so
+# the prior centres do the work and the implied outbreak size rides on them.
+#
+# This script quantifies that pull two ways:
+#   (A) Leave-one-out on the JOINT: fit with isolation included vs excluded
+#       (exclude by passing an empty isolation_history) and compare C_T. If
+#       isolation pins C_T low, removing it should RAISE the joint C_T.
+#   (B) Assumption variants on the ISOLATION SINGLE-STREAM
+#       (treatment_only_model): baseline; a lower admission prior
+#       (Beta(2,6), mean 0.25); and a shorter BVD length-of-stay. Whichever
+#       variant moves the single-stream C_T the most is the dominant driver.
+#
+# Small NUTS (samples=200, chains=2) — enough to read the medians/intervals,
+# not a production fit. Run: julia --project=. scripts/experiment_isolation_sensitivity.jl
+
+using BVDOutbreakSize
+using BVDOutbreakSize: treatment_admission_model, isolation_admission_model,
+    censored_delay_model, cdf_nmax, lognormal_meansd
+using Turing: truncated, Normal, Beta
+using Statistics: median
+using Printf: @printf
+
+obs = load_observations()
+const N = obs.n
+const BP = obs.n - obs.who_first_sitrep_days
+const EMPTY_HISTORY = (; days = Int[], counts = Int[])
+
+const SAMPLES = 200
+const CHAINS = 2
+
+_C(chn) = vec(Array(chn[:C_T]))
+
+function _summarise(label, draws)
+    s = posterior_summary(draws)
+    @printf("%-34s median=%8.0f   90%% CI [%8.0f, %8.0f]   60%% CI [%8.0f, %8.0f]\n",
+        label, median(draws), s.lo90, s.hi90, s.lo60, s.hi60)
+    return draws
+end
+
+# ---------------------------------------------------------------------------
+# (A) Joint leave-one-out: isolation included vs excluded.
+# ---------------------------------------------------------------------------
+# Mirrors the analysis.jl joint call. Excluding isolation = passing an empty
+# isolation_history (and empty bed_capacity_history): the treatment submodel
+# then samples from the prior and contributes no likelihood, so its pull on
+# C_T disappears while every other stream is unchanged.
+function joint_model(; include_isolation::Bool)
+    iso = include_isolation ? obs.isolation_history : EMPTY_HISTORY
+    cap = include_isolation ? obs.bed_capacity_history : EMPTY_HISTORY
+    return bvd_joint(obs.n, obs.exported_cases, obs.total_deaths,
+        obs.reported_cases, obs.exports_deaths, obs.confirmed_cases,
+        obs.tests_analysed;
+        confirmed_deaths = obs.confirmed_deaths,
+        recovered_cases = obs.recovered_cases,
+        deaths_history = obs.deaths_history,
+        reported_history = obs.reported_history,
+        confirmed_history = obs.confirmed_history,
+        confirmed_deaths_history = obs.confirmed_deaths_history,
+        lab_history = obs.lab_history,
+        lab_daily_history = obs.lab_daily_history,
+        suspected_daily_history = obs.suspected_daily_history,
+        suspected_daily_deaths_history = obs.suspected_daily_deaths_history,
+        isolation_history = iso,
+        bed_capacity_history = cap,
+        recovered_history = obs.recovered_history,
+        export_case_days = obs.export_case_days,
+        export_death_days = obs.export_death_days,
+        breakpoint = BP, background_re = true,
+        confirmed_positivity_link = :composition,
+        genetic = genetic_seeding_model, tmrca_days = obs.tmrca_days)
+end
+
+println("=== (A) Joint leave-one-out: isolation IN vs OUT ===")
+chn_joint_with = nuts_sample(joint_model(; include_isolation = true);
+    samples = SAMPLES, chains = CHAINS, progress = false)
+chn_joint_without = nuts_sample(joint_model(; include_isolation = false);
+    samples = SAMPLES, chains = CHAINS, progress = false)
+C_joint_with = _C(chn_joint_with)
+C_joint_without = _C(chn_joint_without)
+
+# ---------------------------------------------------------------------------
+# (B) Isolation single-stream under assumption variants.
+# ---------------------------------------------------------------------------
+# treatment_only_model takes a `treatment` keyword (default
+# treatment_admission_model). We inject closures that forward to
+# treatment_admission_model with alternate submodels/priors, keeping the call
+# signature (isolation_history, bvd_reports_daily, bg_daily, p_drc; kwargs).
+#
+#  - baseline:        the shipped priors (p_iso ~ Beta(2,2), BVD LOS ~12 d).
+#  - low admission:   admission = isolation_admission_model(p_prior=Beta(2,6))
+#                     (mean 0.25 instead of 0.5) -> for a fixed bed count,
+#                     fewer admitted per suspect implies MORE suspects -> C_T up.
+#  - short BVD LOS:    BVD stay re-centred on ~6 d instead of ~12 d -> beds
+#                     turn over faster, so a fixed occupancy implies a higher
+#                     inflow -> C_T up.
+#
+# Whichever variant raises the single-stream C_T most is the assumption that
+# most pins it low at baseline.
+
+# Shorter BVD length-of-stay delay submodel (mean prior 6 d vs the shipped
+# 12 d), matching the truncation style of the shipped default.
+short_bvd_los() = censored_delay_model(
+    cdf_nmax(lognormal_meansd(6.0, 5.0); q = 0.99);
+    mean_prior = truncated(Normal(6.0, 3.0); lower = 1),
+    sd_prior = truncated(Normal(5.0, 3.0); lower = 1))
+
+treatment_baseline(args...; kw...) = treatment_admission_model(args...; kw...)
+
+treatment_low_admission(args...; kw...) = treatment_admission_model(args...;
+    admission = isolation_admission_model(; p_prior = Beta(2.0, 6.0)), kw...)
+
+treatment_short_los(args...; kw...) = treatment_admission_model(args...;
+    bvd_los = short_bvd_los(), kw...)
+
+function treatment_only(; treatment = treatment_admission_model)
+    return treatment_only_model(obs.n;
+        isolation_history = obs.isolation_history,
+        bed_capacity_history = obs.bed_capacity_history,
+        breakpoint = BP, treatment = treatment)
+end
+
+println("\n=== (B) Isolation single-stream variants ===")
+chn_iso_base = nuts_sample(treatment_only(; treatment = treatment_baseline);
+    samples = SAMPLES, chains = CHAINS, progress = false)
+chn_iso_lowadm = nuts_sample(treatment_only(; treatment = treatment_low_admission);
+    samples = SAMPLES, chains = CHAINS, progress = false)
+chn_iso_shortlos = nuts_sample(treatment_only(; treatment = treatment_short_los);
+    samples = SAMPLES, chains = CHAINS, progress = false)
+
+C_iso_base = _C(chn_iso_base)
+C_iso_lowadm = _C(chn_iso_lowadm)
+C_iso_shortlos = _C(chn_iso_shortlos)
+
+# ---------------------------------------------------------------------------
+# Comparison tables.
+# ---------------------------------------------------------------------------
+println("\n================  C_T comparison (cumulative infections at cut-off)  ================")
+println("\n(A) Joint leave-one-out:")
+_summarise("joint, isolation INCLUDED", C_joint_with)
+_summarise("joint, isolation EXCLUDED", C_joint_without)
+@printf("  -> excluding isolation moves the joint median by %+.0f infections\n",
+    median(C_joint_without) - median(C_joint_with))
+
+println("\n(B) Isolation single-stream assumption variants:")
+_summarise("baseline (p_iso~Beta(2,2), LOS~12d)", C_iso_base)
+_summarise("low admission (p_iso~Beta(2,6))", C_iso_lowadm)
+_summarise("short BVD LOS (~6d)", C_iso_shortlos)
+@printf("  -> low-admission moves median by %+.0f; short-LOS moves median by %+.0f\n",
+    median(C_iso_lowadm) - median(C_iso_base),
+    median(C_iso_shortlos) - median(C_iso_base))
+
+# streams_table for a tidy DataFrame view (same helper the report uses).
+tbl = streams_table(
+    "joint (iso in)" => C_joint_with,
+    "joint (iso out)" => C_joint_without,
+    "iso baseline" => C_iso_base,
+    "iso low-admission" => C_iso_lowadm,
+    "iso short-LOS" => C_iso_shortlos)
+println("\nstreams_table view:")
+show(stdout, tbl)
+println()
+
+# Optional figure: overlay the C_T posteriors.
+try
+    import CairoMakie
+    fig = CairoMakie.Figure(size = (900, 500))
+    ax = CairoMakie.Axis(fig[1, 1]; xlabel = "cumulative infections C_T",
+        ylabel = "density",
+        title = "Isolation pull on the outbreak size (C_T)")
+    for (label, draws, col) in [
+            ("joint (iso in)", C_joint_with, :firebrick),
+            ("joint (iso out)", C_joint_without, :seagreen),
+            ("iso baseline", C_iso_base, :darkorange),
+            ("iso low-admission", C_iso_lowadm, :steelblue),
+            ("iso short-LOS", C_iso_shortlos, :purple)]
+        CairoMakie.density!(ax, draws; label = label, color = (col, 0.25),
+            strokecolor = col, strokewidth = 2)
+    end
+    CairoMakie.axislegend(ax)
+    mkpath("logs")
+    CairoMakie.save("logs/isolation_sensitivity_C_T.png", fig)
+    println("saved logs/isolation_sensitivity_C_T.png")
+catch err
+    @warn "figure step skipped" err
+end
+
+println("\nDone. Read (A) to see whether isolation pins the joint low, and (B) ",
+    "to see which assumption (admission fraction vs BVD length-of-stay) drives it.")

--- a/scripts/experiment_isolation_sensitivity.jl
+++ b/scripts/experiment_isolation_sensitivity.jl
@@ -28,7 +28,7 @@
 
 using BVDOutbreakSize
 using BVDOutbreakSize: treatment_admission_model, isolation_admission_model,
-    censored_delay_model, cdf_nmax, lognormal_meansd
+                       censored_delay_model, cdf_nmax, lognormal_meansd
 using Turing: truncated, Normal, Beta
 using Statistics: median
 using Printf: @printf
@@ -112,18 +112,24 @@ C_joint_without = _C(chn_joint_without)
 
 # Shorter BVD length-of-stay delay submodel (mean prior 6 d vs the shipped
 # 12 d), matching the truncation style of the shipped default.
-short_bvd_los() = censored_delay_model(
-    cdf_nmax(lognormal_meansd(6.0, 5.0); q = 0.99);
-    mean_prior = truncated(Normal(6.0, 3.0); lower = 1),
-    sd_prior = truncated(Normal(5.0, 3.0); lower = 1))
+function short_bvd_los()
+    censored_delay_model(
+        cdf_nmax(lognormal_meansd(6.0, 5.0); q = 0.99);
+        mean_prior = truncated(Normal(6.0, 3.0); lower = 1),
+        sd_prior = truncated(Normal(5.0, 3.0); lower = 1))
+end
 
 treatment_baseline(args...; kw...) = treatment_admission_model(args...; kw...)
 
-treatment_low_admission(args...; kw...) = treatment_admission_model(args...;
-    admission = isolation_admission_model(; p_prior = Beta(2.0, 6.0)), kw...)
+function treatment_low_admission(args...; kw...)
+    treatment_admission_model(args...;
+        admission = isolation_admission_model(; p_prior = Beta(2.0, 6.0)), kw...)
+end
 
-treatment_short_los(args...; kw...) = treatment_admission_model(args...;
-    bvd_los = short_bvd_los(), kw...)
+function treatment_short_los(args...; kw...)
+    treatment_admission_model(args...;
+        bvd_los = short_bvd_los(), kw...)
+end
 
 function treatment_only(; treatment = treatment_admission_model)
     return treatment_only_model(obs.n;
@@ -181,11 +187,11 @@ try
         ylabel = "density",
         title = "Isolation pull on the outbreak size (C_T)")
     for (label, draws, col) in [
-            ("joint (iso in)", C_joint_with, :firebrick),
-            ("joint (iso out)", C_joint_without, :seagreen),
-            ("iso baseline", C_iso_base, :darkorange),
-            ("iso low-admission", C_iso_lowadm, :steelblue),
-            ("iso short-LOS", C_iso_shortlos, :purple)]
+        ("joint (iso in)", C_joint_with, :firebrick),
+        ("joint (iso out)", C_joint_without, :seagreen),
+        ("iso baseline", C_iso_base, :darkorange),
+        ("iso low-admission", C_iso_lowadm, :steelblue),
+        ("iso short-LOS", C_iso_shortlos, :purple)]
         CairoMakie.density!(ax, draws; label = label, color = (col, 0.25),
             strokecolor = col, strokewidth = 2)
     end


### PR DESCRIPTION
## Question

In recent dev fits the joint posterior outbreak size `C_T` (cumulative infections at the cut-off) is being **pinned low by the isolation/treatment-bed stream**. The other single-stream fits individually want a much larger outbreak, but the joint ends up near the bottom of the isolation stream's range. This PR adds a focused sensitivity experiment to confirm and quantify that pull, and a notes writeup.

This is confirmed in the released analysis (per-stream `C_T`, 90% CrI):

| stream | 90% CrI of C_T |
|---|---|
| exports | 915 – 25 733 |
| deaths (DRC) | 4 866 – 19 289 |
| cases (DRC) | 5 867 – 17 429 |
| confirmed (DRC) | 7 412 – 28 773 |
| **isolation** | **1 548 – 12 869** |
| **joint** | **1 723 – 4 112** |

Deaths/cases/confirmed all want several thousand to tens of thousands; isolation is the single-stream fit whose lower bound anchors the joint, and the joint lands near the bottom of it.

## Mechanism

The isolation occupancy (`treatment_admission_model`) reads the observed occupied-bed count into a suspect inflow via a length-of-stay survival. By Little's law (per the `isolation_admission_model` docstring):

```
mean occupancy  ≈  p_iso · admissions · (E[LOS] + 1)
```

The bed count is observed (~376 at the cut-off), so for a fixed occupancy a **high admission fraction × long stay** implies *few* admitted suspects, hence a *small* outbreak. `p_iso` and `E[LOS]` are explicitly confounded for the occupancy *level* — only their product is pinned by the level — so the implied size rides on the priors.

## Hypothesis

The low pin is driven by the **admission fraction `p_iso` (`Beta(2,2)`, mean 0.5) × BVD length-of-stay (~12 d) product** being effectively high and weakly identified. The released isolation posteriors are consistent: `isolation_admission` 90% CrI 0.19–0.54 (data pulls it down from 0.5 but it stays substantial and wide), BVD LOS mean 90% CrI 5.4–19.3 d (median ~12 d, essentially the prior).

## What the script tests (`scripts/experiment_isolation_sensitivity.jl`)

Small NUTS (samples=200, chains=2), reading posterior `C_T`:

- **(A) Joint leave-one-out** — fit the joint with isolation *included* vs *excluded* (excluded by passing an empty `isolation_history`, so the treatment submodel samples from its prior and adds no likelihood). If isolation pins `C_T` low, excluding it should **raise** the joint `C_T`.
- **(B) Isolation single-stream variants** (`treatment_only_model`, injecting alternate submodels via the `treatment` keyword): *baseline*; *low admission* (`admission = isolation_admission_model(p_prior = Beta(2,6))`, mean 0.25); *short BVD LOS* (~6 d). Both alternatives reduce the `p_iso · E[LOS]` product and should **raise** the single-stream `C_T`; the larger mover is the dominant driver.

It prints a `C_T` comparison table across all five settings and saves a density overlay to `logs/isolation_sensitivity_C_T.png`. Also adds `notes/isolation-pinning.md` (mechanism, hypothesis, how to read the output, reasonableness judgement). **Diagnostic only — the model is not modified.**

## ⚠️ Not validated — please run

I could **not run Julia in this environment** (no Manifest / runnable Julia toolchain here), so **the script is unvalidated and needs to be run** with:

```
julia --project=. scripts/experiment_isolation_sensitivity.jl
```

API names (`bvd_joint`/`treatment_only_model` keywords, `treatment` submodel injection, `isolation_admission_model(; p_prior=...)`, `censored_delay_model`/`cdf_nmax`/`lognormal_meansd`, `streams_table`, `posterior_summary`, `nuts_sample`) were verified against the current source, but the closure-injection and the fits themselves have not executed. Worth checking on first run:

- the `treatment = treatment_*` closures slot into `treatment_only_model` (call shape `treatment(iso, bvd_daily, bg_daily, p_drc; capacity_history=...)`);
- the empty-`isolation_history` exclusion path samples cleanly in the joint;
- `Beta` / `truncated` / `Normal` resolve from the `using Turing` import.

### What to look for in the output

- **(A):** "joint, isolation EXCLUDED" median **higher** than "...INCLUDED" confirms the pin; the printed delta quantifies it in infections. Expectation: excluding isolation lifts the joint toward the deaths/cases consensus.
- **(B):** *low admission* and/or *short BVD LOS* raising the single-stream `C_T` confirms which assumption drives the pin; compare the two deltas to rank admission fraction vs length-of-stay.

## Reasonableness (preliminary, pending the run)

Structurally sound — occupancy genuinely is admissions × stay. The concern is **identifiability**: only the product `p_iso · E[LOS]` is pinned by the occupancy level, so the implied outbreak size is effectively set by the priors, and `Beta(2,2)` (mean-0.5 admission) × ~12 d stay is a fairly aggressive high-retention assumption. The pin is **plausible but fragile** — reasonable if ~half of ascertained suspects occupy a bed for ~12 days, but not something to lean on otherwise, since the data barely constrains that product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHAmKzbLQvzqEfXcTSYXkg)_