### PR TITLE
feat(report): add per-stream posterior-predictive calibration table

### DIFF
--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -3063,7 +3063,7 @@ joint_vintage_incidence_fig = plot_vintage_incidence_ppc(
 joint_vintage_incidence_fig #hide
 
 # The above plot is useful for building an intuition for which panels track the data well, but to quantify it we
-# score each stream's per-vintage conditional predictive against the
+# score each stream's per-vintage conditional predictions against the
 # observed counts. `bias` is the mean forecast bias over the vintages
 # (negative = the stream is under-predicted, positive = over-predicted, zero
 # = the observed counts sit at the predictive median); `50%/90% coverage`

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -3027,10 +3027,11 @@ recovered_panel = (;
 ## laboratory-confirmed streams keep reporting to the cut-off, so the
 ## confirmed panels show the full series the model is fitting, not just the
 ## window the suspected streams cover.
-joint_vintage_ppc_fig = plot_vintage_conditional_ppc(
-    [reported_panel, suspected_daily_panel, isolation_panel, confirmed_panel,
+vintage_panels = [
+    reported_panel, suspected_daily_panel, isolation_panel, confirmed_panel,
     deaths_panel, suspected_daily_deaths_panel, confirmed_deaths_panel,
-    recovered_panel, tests_analysed_panel, tests_analysed_daily_panel]);
+    recovered_panel, tests_analysed_panel, tests_analysed_daily_panel];
+joint_vintage_ppc_fig = plot_vintage_conditional_ppc(vintage_panels);
 
 #md # ```@raw html
 #md # </details>
@@ -3060,6 +3061,28 @@ joint_vintage_incidence_fig = plot_vintage_incidence_ppc(
 #md # ```
 
 joint_vintage_incidence_fig #hide
+
+# The eye can tell which panels track the data well, but to quantify it we
+# score each stream's per-vintage conditional predictive against the
+# observed counts. `bias` is the mean forecast bias over the vintages
+# (negative = the stream is under-predicted, positive = over-predicted, zero
+# = the observed counts sit at the predictive median); `50%/90% coverage`
+# are the fractions of vintages whose observed count falls inside the central
+# 50% and 90% predictive intervals, which a well-calibrated stream keeps near
+# those nominal levels. Streams with a large bias or coverage far from
+# nominal are the ones the joint fit reproduces less well.
+
+#md # ```@raw html
+#md # <details><summary>Per-stream calibration table</summary>
+#md # ```
+
+stream_calibration_table = stream_calibration(vintage_panels);
+
+#md # ```@raw html
+#md # </details>
+#md # ```
+
+stream_calibration_table #hide
 
 # The exports group is checked next.
 # The Uganda export and export-death streams are dated per-day series, each

--- a/docs/examples/analysis.jl
+++ b/docs/examples/analysis.jl
@@ -3062,7 +3062,7 @@ joint_vintage_incidence_fig = plot_vintage_incidence_ppc(
 
 joint_vintage_incidence_fig #hide
 
-# The eye can tell which panels track the data well, but to quantify it we
+# The above plot is useful for building an intuition for which panels track the data well, but to quantify it we
 # score each stream's per-vintage conditional predictive against the
 # observed counts. `bias` is the mean forecast bias over the vintages
 # (negative = the stream is under-predicted, positive = over-predicted, zero

--- a/docs/src/news.md
+++ b/docs/src/news.md
@@ -158,6 +158,12 @@ Changes since v1.5.0.
   27 May 2026 Lancet publication, plotted beside our renewal estimate on
   27 May, with a frozen re-fit at the 27 May cut-off added to the
   frozen-fit outbreak-size table.
+- Quantified the per-vintage posterior-predictive checks with a per-stream
+  calibration table (`stream_calibration`): the mean forecast bias and the
+  empirical 50%/90% interval coverage of each stream's one-step-ahead
+  conditional predictive, so the streams the joint fit reproduces less well
+  can be read off rather than eyeballed. Added the `bias_sample` scoring
+  helper (resolves #269).
 
 ### Documentation
 

--- a/src/BVDOutbreakSize.jl
+++ b/src/BVDOutbreakSize.jl
@@ -1,6 +1,6 @@
 module BVDOutbreakSize
 
-using Statistics: quantile
+using Statistics: quantile, mean
 using TOML: TOML
 using DataFrames: DataFrame, rename
 using Chain: @chain
@@ -32,7 +32,8 @@ export REPORT_SCENARIOS, REPORT_SCENARIOS_CI,
        load_observations, freeze_observations, m_prior_centre,
        summary_table, posterior_summary, markdown_table,
        fit_diagnostics, diagnostics_table,
-       streams_table, comparison_table, onsets_over_time,
+       streams_table, comparison_table,
+       bias_sample, stream_calibration, onsets_over_time,
        nuts_sample, fit_parallel, default_adtype, enzyme_adtype,
        progress_callback, tensorboard_callback,
        combined_callback, fit_callback,

--- a/src/summaries.jl
+++ b/src/summaries.jl
@@ -35,7 +35,9 @@ const _PRETTY_COLS = Dict(
     "horizon_days" => "Horizon (days)",
     "lower_90" => "Lower 90%", "lower_60" => "Lower 60%",
     "lower_30" => "Lower 30%", "upper_30" => "Upper 30%",
-    "upper_60" => "Upper 60%", "upper_90" => "Upper 90%"
+    "upper_60" => "Upper 60%", "upper_90" => "Upper 90%",
+    "n" => "Vintages", "bias" => "Bias",
+    "coverage_50" => "50% coverage", "coverage_90" => "90% coverage"
 )
 
 _prettify(df::DataFrame) = rename(df, [n => get(_PRETTY_COLS, n, n) for n in names(df)])
@@ -246,6 +248,86 @@ function comparison_table(C_draws::AbstractVector;
         end
         (scenario = label, reported_cases = val,
             narrowest_interval = crI)
+    end
+    return _prettify(DataFrame(rows))
+end
+
+## --- Posterior-predictive calibration -----------------------------------
+
+"""
+Sample-based forecast bias for a single observation against a predictive
+sample, following `scoringutils::bias_sample`. With `n_lt` and `n_eq` the
+counts of predictive draws strictly below and exactly equal to the
+observation, the bias is
+
+``1 - 2\\,(n_{lt} + n_{eq}/2)/m``
+
+over the `m` draws. It lies in ``[-1, 1]``: negative when the predictive
+distribution sits below the observation (under-prediction), positive when
+it sits above (over-prediction), and zero when the observation falls at the
+predictive median. The equal-count term handles ties in count data so a
+mass of draws exactly at the observation does not bias the score.
+"""
+function bias_sample(observed::Real, predicted::AbstractVector{<:Real})
+    m = length(predicted)
+    m == 0 && return NaN
+    n_lt = count(<(observed), predicted)
+    n_eq = count(==(observed), predicted)
+    return 1 - 2 * (n_lt + n_eq / 2) / m
+end
+
+# Whether `observed` lies inside the central equal-tailed `level` predictive
+# interval of the sample (e.g. `level = 0.9` → the 5–95% interval).
+function _covered(observed::Real, predicted::AbstractVector{<:Real}, level::Real)
+    lo = quantile(predicted, (1 - level) / 2)
+    hi = quantile(predicted, (1 + level) / 2)
+    return lo <= observed <= hi
+end
+
+# Per-vintage conditional predictive samples for one PPC panel, mirroring
+# `plot_vintage_conditional_ppc`: each cumulative-stream draw at vintage `v`
+# is the observed previous cumulative plus the drawn increment (baseline
+# zero for a `cumulative = false` daily panel), and the matching observed
+# value is the cumulative (or daily) count at that vintage. Returns
+# `(samples, observed)` with `samples[v]` the draw vector at vintage `v`.
+function _panel_conditional(panel)
+    observed = float.(panel.observed)
+    n = length(observed)
+    cumulative = get(panel, :cumulative, true)
+    obs_prev = cumulative ?
+               [v == 1 ? 0.0 : observed[v - 1] for v in 1:n] : zeros(n)
+    replicates = [collect(r) for r in vec(collect(panel.replicates))]
+    samples = [[obs_prev[v] + r[v] for r in replicates] for v in 1:n]
+    return (samples = samples, observed = observed)
+end
+
+"""
+Per-stream posterior-predictive calibration for the per-vintage
+one-step-ahead conditional checks. Pass the same `panels` given to
+[`plot_vintage_conditional_ppc`](@ref): each is a `NamedTuple`
+`(; title, observed, replicates, …)` with optional `cumulative`. For each
+stream the conditional predictive at every vintage is scored against the
+observed count, and the per-vintage scores are averaged into one row.
+
+Columns: `stream`, the number of scored vintages `n`, the mean forecast
+`bias` (see [`bias_sample`](@ref); negative = the stream is under-predicted,
+positive = over-predicted), and the empirical `coverage_50`/`coverage_90`
+— the fraction of vintages whose observed count falls inside the central
+50% and 90% predictive intervals. A well-calibrated stream has bias near
+zero and coverage near its nominal level; departures flag the streams the
+joint fit reproduces less well.
+"""
+function stream_calibration(panels::AbstractVector)
+    rows = map(panels) do panel
+        c = _panel_conditional(panel)
+        n = length(c.observed)
+        biases = [bias_sample(c.observed[v], c.samples[v]) for v in 1:n]
+        cov50 = [_covered(c.observed[v], c.samples[v], 0.5) for v in 1:n]
+        cov90 = [_covered(c.observed[v], c.samples[v], 0.9) for v in 1:n]
+        (stream = panel.title, n = n,
+            bias = round(n == 0 ? NaN : mean(biases); digits = 2),
+            coverage_50 = round(n == 0 ? NaN : mean(cov50); digits = 2),
+            coverage_90 = round(n == 0 ? NaN : mean(cov90); digits = 2))
     end
     return _prettify(DataFrame(rows))
 end

--- a/test/test_stream_calibration.jl
+++ b/test/test_stream_calibration.jl
@@ -1,0 +1,86 @@
+## Tests for the per-stream posterior-predictive calibration metrics:
+## `bias_sample` and the `stream_calibration` summary table.
+
+@testitem "bias_sample matches the scoringutils sign convention" begin
+    using BVDOutbreakSize: bias_sample
+
+    pred = collect(1.0:100.0)
+    ## Observation at the predictive median → zero bias.
+    @test abs(bias_sample(50.5, pred)) < 1e-9
+    ## Observation above the whole sample → the stream is under-predicted.
+    @test bias_sample(200.0, pred) == -1.0
+    ## Observation below the whole sample → over-predicted.
+    @test bias_sample(-5.0, pred) == 1.0
+    ## Ties are split half-and-half: a sample all equal to the observation
+    ## gives zero bias.
+    @test bias_sample(7.0, fill(7.0, 10)) == 0.0
+    ## Empty predictive sample is undefined.
+    @test isnan(bias_sample(1.0, Float64[]))
+end
+
+@testitem "stream_calibration scores a well-calibrated cumulative panel" begin
+    using BVDOutbreakSize: stream_calibration
+    using DataFrames: DataFrame, nrow
+    using Random: MersenneTwister
+
+    rng = MersenneTwister(1)
+    ## Observed cumulative counts with a constant increment of 10. Each draw
+    ## carries a per-vintage increment vector centred (symmetrically) on 10,
+    ## so the conditional cumulative sits with its median on the observed
+    ## count at every vintage: bias ≈ 0 and coverage ≈ nominal.
+    observed = [10, 20, 30, 40]
+    ndraw = 4_000
+    replicates = [10 .+ rand(rng, -5:5, length(observed)) for _ in 1:ndraw]
+    panel = (; title = "Calibrated", observed = observed,
+        replicates = replicates)
+
+    df = stream_calibration([panel])
+    @test df isa DataFrame
+    @test names(df) ==
+          ["Stream", "Vintages", "Bias", "50% coverage", "90% coverage"]
+    @test nrow(df) == 1
+    @test df[1, "Stream"] == "Calibrated"
+    @test df[1, "Vintages"] == length(observed)
+    @test abs(df[1, "Bias"]) < 0.1
+    @test df[1, "90% coverage"] == 1.0
+end
+
+@testitem "stream_calibration detects over- and under-prediction" begin
+    using BVDOutbreakSize: stream_calibration
+    using DataFrames: DataFrame
+
+    observed = [10, 20, 30]
+    ## Increments far above the observed increment of 10 → the conditional
+    ## cumulative sits above the observed count everywhere → positive bias
+    ## (over-prediction) and the observed never falls inside the interval.
+    over = (; title = "Over", observed = observed,
+        replicates = [fill(40.0, length(observed)) for _ in 1:200])
+    ## Increments far below → negative bias (under-prediction).
+    under = (; title = "Under", observed = observed,
+        replicates = [fill(1.0, length(observed)) for _ in 1:200])
+
+    df = stream_calibration([over, under])
+    @test df[1, "Bias"] == 1.0
+    @test df[1, "90% coverage"] == 0.0
+    @test df[2, "Bias"] == -1.0
+    @test df[2, "90% coverage"] == 0.0
+end
+
+@testitem "stream_calibration handles a non-cumulative daily panel" begin
+    using BVDOutbreakSize: stream_calibration
+    using Random: MersenneTwister
+
+    rng = MersenneTwister(2)
+    ## A `cumulative = false` panel has no previous-vintage baseline: each
+    ## replicate is its own daily count, scored directly against the observed
+    ## daily count. Centre the draws on the observed value for calibration.
+    observed = [5, 8, 3, 6]
+    replicates = [observed .+ rand(rng, -2:2, length(observed)) for _ in 1:3_000]
+    panel = (; title = "Daily", observed = observed,
+        replicates = replicates, cumulative = false)
+
+    df = stream_calibration([panel])
+    @test df[1, "Vintages"] == length(observed)
+    @test abs(df[1, "Bias"]) < 0.1
+    @test df[1, "90% coverage"] == 1.0
+end


### PR DESCRIPTION
Quantifies the per-vintage posterior-predictive checks in the analysis report with a per-stream calibration table. For each surveillance stream's one-step-ahead conditional predictive it reports:

- the **mean forecast bias** over the vintages (negative = under-predicted, positive = over-predicted, 0 = observed at the predictive median), via a new `bias_sample` helper following `scoringutils::bias_sample`;
- the empirical **50% and 90% interval coverage**.

So the streams the joint fit reproduces less well (large bias, or coverage far from nominal) can be read off rather than eyeballed.

- `src/summaries.jl` — `bias_sample`, `stream_calibration`
- `docs/examples/analysis.jl` — table rendered after the vintage PPC panels
- `test/test_stream_calibration.jl`, news entry

This PR closes #269.
